### PR TITLE
商品画像追加のajax を実装する

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,7 +12,6 @@
 //
 //= require rails-ujs
 //= require activestorage
-//= require turbolinks
 //= require jquery
 //= require jquery_ujs
 //= require_tree .

--- a/app/assets/javascripts/image.js
+++ b/app/assets/javascripts/image.js
@@ -1,0 +1,59 @@
+$(function () {
+
+  function buildHtmlAddImage(data, blobUrl) {
+    var html = `<div class="sell-dropbox-item">
+                  <figure class="sell-upload-image">
+                    <img id="file-preview" src="${blobUrl}">
+                    <input name='item[images][]' type='hidden' value='${data.image_id}' multiple="multiple" id="item_images">
+                  </figure>
+                  <div class="sell-upload-edit-button">
+                    <a href="">編集</a>
+                    <a href class="sell-upload-image-delete">削除</a>
+                  </div>
+                </div>`
+    return html;
+  }
+
+  $(".sell-upload-drop-file").on('change',  function(e) {
+      var file = e.target.files[0];
+      var formData = new FormData();
+      formData.append('image', file);
+      var blobUrl = window.URL.createObjectURL(file);
+      $.ajax({
+        type: "POST",
+        url: "/items/upload_image",
+        data: formData,
+        dataType: 'json',
+        processData: false,
+        contentType: false,
+      })
+      .done(function(data) {
+        var html = buildHtmlAddImage(data,blobUrl);
+        if($(".sell-dropbox-wrap").children().length < 6) {
+          $(".sell-dropbox-wrap").prepend(html);
+        } else {
+          $(".sell-dropbox-upload-item").css("display", "none");
+          $(".sell-dropbox-wrap").prepend(html);
+        }
+      })
+      .fail(function(){
+        alert("fail")
+      })
+      $('.sell-upload-drop-file').val('');
+    });
+
+
+    $(".sell-dropbox-wrap").on("click", ".sell-upload-image-delete",function(e) {
+      e.preventDefault();
+      var parent = $(this).parent().parent();
+      parent.remove();
+      if($(".sell-dropbox-wrap").children().length < 7) {
+        $(".sell-dropbox-upload-item").css("display", "block");
+      }
+    });
+
+    $(".sell-dropbox-upload-item").on("click", function(e){
+      $('.sell-upload-drop-file').trigger('click');
+    })
+
+});

--- a/app/assets/stylesheets/items/_itemExhibit.scss
+++ b/app/assets/stylesheets/items/_itemExhibit.scss
@@ -41,8 +41,8 @@
   display: flex;
 }
 
-.sell-dropbox-item {
-  width: 20%;
+.sell-dropbox-upload-item {
+  flex: 1;
   margin-left: 0;
   margin-right: 10px;
   position: relative;
@@ -69,8 +69,32 @@
   }
 }
 
-.sell-dropbox-item:last-child {
-  flex: 1;
+.sell-dropbox-item {
+  width: 18%;
+  margin-left: 0;
+  margin-right: 10px;
+  position: relative;
+  min-height: 162px;
+  background: #f5f5f5;
+  border: 1px dashed #ccc;
+  text-align: center;
+  cursor: pointer;
+
+  pre {
+    position: absolute;
+    top: 50%;
+    left: 16px;
+    right: 16px;
+    text-align: center;
+    font-size: 14px;
+    line-height: 1.5;
+    -webkit-transform: translate(0, -50%);
+    transform: translate(0, -50%);
+    pointer-events: none;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    display: block;
+  }
 }
 
 .sell-upload-image {
@@ -106,7 +130,7 @@
   outline: 0;
   font-family: inherit;
   -webkit-appearance: none;
-
+  display: none;
 }
 
 .sell-content {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,8 +24,27 @@ class ItemsController < ApplicationController
     end
   end
 
+  def upload_image
+    @image_blob = create_blob(params[:image])
+    respond_to do |format|
+      format.json { @image_blob.id }
+    end
+  end
+
   private
     def item_params
-      params.require(:item).permit(:name, :description, :size, :condition, :delivery_fee, :delivery_date, :delivery_area, :delivery_way, :price, :status, images: []).merge(user_id: "1")
+      params.require(:item).permit(:name, :description, :size, :condition, :delivery_fee, :delivery_date, :delivery_area, :delivery_way, :price, :status).merge(user_id: "1", images: uploaded_images)
     end
+
+    def create_blob(uploading_file)
+      ActiveStorage::Blob.create_after_upload! \
+        io: uploading_file.open,
+        filename: uploading_file.original_filename,
+        content_type: uploading_file.content_type
+    end
+
+    def uploaded_images
+      params[:item][:images].map{|id| ActiveStorage::Blob.find(id)} if params[:item][:images]
+    end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -33,7 +33,7 @@ class ItemsController < ApplicationController
 
   private
     def item_params
-      params.require(:item).permit(:name, :description, :size, :condition, :delivery_fee, :delivery_date, :delivery_area, :delivery_way, :price, :status).merge(user_id: "1", images: uploaded_images)
+      params.require(:item).permit(:name, :description, :size, :condition, :delivery_fee, :delivery_date, :delivery_area, :delivery_way, :price, :status).merge(user_id: User.first.id, images: uploaded_images)
     end
 
     def create_blob(uploading_file)

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -8,23 +8,13 @@
         %h3.sell-upload-box-head
           出品画像
           %span.form-require 必須
-        %p 最大10枚までアップロードできます
+        %p 最大5枚までアップロードできます
         .sell-dropbox-wrap
-          .sell-dropbox-item
-            %figure.sell-upload-image
-              = image_tag "discover.png"
-            .sell-upload-edit-button
-              =link_to "編集", items_path
-              =link_to "削除", items_path
-          .sell-dropbox-item
-            %figure.sell-upload-image
-              = image_tag "discover.png"
-            .sell-upload-edit-button
-              =link_to "編集", items_path
-              =link_to "削除", items_path
-          .sell-dropbox-item
-            = f.file_field :images, class: "sell-upload-drop-file image-input-form", multiple: true do
-              %pre ドラッグアンドドロップまたはクリックしてファイルをアップロード
+          = f.file_field :images, class: "sell-upload-drop-file image-input-form", multiple: true
+          .sell-dropbox-upload-item
+            %pre クリックしてファイルをアップロード
+          -# = f.label :images, class: "sell-dropbox-item" do
+            -# %pre ドラッグアンドドロップまたはクリックしてファイルをアップロード
       .sell-content
         .form-group
           = f.label :name, "商品名"

--- a/app/views/items/upload_image.json.jbuilder
+++ b/app/views/items/upload_image.json.jbuilder
@@ -1,0 +1,1 @@
+json.image_id @image_blob.id if @image_blob

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,9 @@ Rails.application.routes.draw do
 
 
   resources :items, only:[:index, :show, :new, :create] do
+    collection do
+      post :upload_image
+    end
     resources :confirmations, only:[:show]
   end
 


### PR DESCRIPTION
# WHAT
商品画像追加をajaxで実装する

# WHY
非同期通信を行い、画像の追加をするたびに画像プレビューをユーザは参照できる。
また追加した画像の削除も行える。