### PR TITLE
商品一覧をカテゴリ別に表示(レディース、メンズ)

### DIFF
--- a/app/assets/stylesheets/_common.scss
+++ b/app/assets/stylesheets/_common.scss
@@ -25,6 +25,34 @@ $hardgray: #ccc;
   color: $white;
 }
 
+@mixin budge {
+  border-color: #ea352d transparent transparent transparent;
+  border-width: 100px 100px 0 0;
+  display: block;
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  width: 0;
+  height: 0;
+  border-style: solid;
+}
+
+@mixin sold {
+  z-index: 2;
+  font-size: 20px;
+  position: absolute;
+  left: 2%;
+  z-index: 2;
+  color: #fff;
+  -webkit-transform: rotate(-45deg);
+  transform: rotate(-45deg);
+  letter-spacing: 2px;
+  font-weight: 600;
+  top: 11%;
+}
+
 body {
   position: relative;
   min-height: 100%;

--- a/app/assets/stylesheets/items/_item.scss
+++ b/app/assets/stylesheets/items/_item.scss
@@ -60,31 +60,11 @@
     }
 
     &__budge {
-      border-color: #ea352d transparent transparent transparent;
-      border-width: 100px 100px 0 0;
-      display: block;
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0;
-      z-index: 1;
-      width: 0;
-      height: 0;
-      border-style: solid;
+      @include budge;
     }
 
     &__sold {
-      z-index: 2;
-      font-size: 20px;
-      position: absolute;
-      left: 2%;
-      z-index: 2;
-      color: #fff;
-      -webkit-transform: rotate(-45deg);
-      transform: rotate(-45deg);
-      letter-spacing: 2px;
-      font-weight: 600;
-      top: 11%;
+      @include sold;
     }
   }
 

--- a/app/assets/stylesheets/items/_item.scss
+++ b/app/assets/stylesheets/items/_item.scss
@@ -58,6 +58,34 @@
       height: 220px;
       object-fit: cover;
     }
+
+    &__budge {
+      border-color: #ea352d transparent transparent transparent;
+      border-width: 100px 100px 0 0;
+      display: block;
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      z-index: 1;
+      width: 0;
+      height: 0;
+      border-style: solid;
+    }
+
+    &__sold {
+      z-index: 2;
+      font-size: 20px;
+      position: absolute;
+      left: 2%;
+      z-index: 2;
+      color: #fff;
+      -webkit-transform: rotate(-45deg);
+      transform: rotate(-45deg);
+      letter-spacing: 2px;
+      font-weight: 600;
+      top: 11%;
+    }
   }
 
   &__body {

--- a/app/assets/stylesheets/items/_itemDetail.scss
+++ b/app/assets/stylesheets/items/_itemDetail.scss
@@ -169,6 +169,19 @@
   font-weight: 600;
 }
 
+.item-not-buy-btn {
+  height: 60px;
+  line-height: 60px;
+  display: block;
+  margin: 16px 0 0;
+  background: #888888;
+  color: #fff;
+  line-height: 56px;
+  text-align: center;
+  font-weight: 600;
+  cursor: not-allowed;
+}
+
 
 .item-description {
   padding: 32px 0 0;

--- a/app/assets/stylesheets/items/_itemDetail.scss
+++ b/app/assets/stylesheets/items/_itemDetail.scss
@@ -50,6 +50,34 @@
           width: 100%;
           vertical-align: bottom;
         }
+
+        &__budge {
+          border-color: #ea352d transparent transparent transparent;
+          border-width: 100px 100px 0 0;
+          display: block;
+          content: '';
+          position: absolute;
+          top: 0;
+          left: 0;
+          z-index: 1;
+          width: 0;
+          height: 0;
+          border-style: solid;
+        }
+
+        &__sold {
+          z-index: 2;
+          font-size: 20px;
+          position: absolute;
+          left: 2%;
+          z-index: 2;
+          color: #fff;
+          -webkit-transform: rotate(-45deg);
+          transform: rotate(-45deg);
+          letter-spacing: 2px;
+          font-weight: 600;
+          top: 11%;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/items/_itemDetail.scss
+++ b/app/assets/stylesheets/items/_itemDetail.scss
@@ -52,31 +52,11 @@
         }
 
         &__budge {
-          border-color: #ea352d transparent transparent transparent;
-          border-width: 100px 100px 0 0;
-          display: block;
-          content: '';
-          position: absolute;
-          top: 0;
-          left: 0;
-          z-index: 1;
-          width: 0;
-          height: 0;
-          border-style: solid;
+         @include budge;
         }
 
         &__sold {
-          z-index: 2;
-          font-size: 20px;
-          position: absolute;
-          left: 2%;
-          z-index: 2;
-          color: #fff;
-          -webkit-transform: rotate(-45deg);
-          transform: rotate(-45deg);
-          letter-spacing: 2px;
-          font-weight: 600;
-          top: 11%;
+          @include sold;
         }
       }
     }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,8 +5,13 @@ class ItemsController < ApplicationController
 
 
   def index
-    @women = Category.find(1)
-    @women_child = @women.children
+    @women_child = Category.where(parent_id: "1").pluck(:id)
+    @women_g_child = Category.where(parent_id: @women_child).pluck(:id)
+    @women_items = Item.where(category_id: @women_g_child).recent
+
+    @men_child = Category.where(parent_id: "78").pluck(:id)
+    @men_g_child = Category.where(parent_id: @men_child).pluck(:id)
+    @men_items = Item.where(category_id: @men_g_child).recent
 
   # binding.pry
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -12,8 +12,6 @@ class ItemsController < ApplicationController
     @men_child = Category.where(parent_id: "78").pluck(:id)
     @men_g_child = Category.where(parent_id: @men_child).pluck(:id)
     @men_items = Item.where(category_id: @men_g_child).recent
-
-  # binding.pry
   end
 
   def show

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,8 +5,10 @@ class ItemsController < ApplicationController
 
 
   def index
+    @women = Category.find(1)
+    @women_child = @women.children
 
-
+  # binding.pry
   end
 
   def show

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -50,5 +50,5 @@ class Item < ApplicationRecord
     self.price = (price * 1.08).round
   end
 
-  scope :recent, -> {order('created_at desc')}
+  scope :recent, -> {order('created_at desc').limit(4)}
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -49,4 +49,6 @@ class Item < ApplicationRecord
   def insert_comma
     self.price = (price * 1.08).round
   end
+
+  scope :recent, -> {order('created_at desc')}
 end

--- a/app/views/items/_index.html.haml
+++ b/app/views/items/_index.html.haml
@@ -1,9 +1,14 @@
 .items-box-contents.clearfix
   - items.each do |item|
     %section.items-box
-      = link_to items_path do
+      = link_to item_path(item) do
         %figure.items-box__image
           = image_tag item.images[0]
+          - if item.status == "sold"
+            .items-box__image__budge
+            .items-box__image__sold
+              SOLD
+
         .items-box__body
           %h3.items-box__body__name
             = item.name

--- a/app/views/items/_index.html.haml
+++ b/app/views/items/_index.html.haml
@@ -1,0 +1,13 @@
+.items-box-contents.clearfix
+  %section.items-box
+    = link_to items_path do
+      %figure.items-box__image
+        = image_tag "/item.jpg"
+      .items-box__body
+        %h3.items-box__body__name チェックロングタイプ
+        .items-box__body__info.clearfix
+          .items-box__body__info__price ¥890
+          .items-box__body__info__likes
+            %i.fa.fa-heart
+            %span 2
+          %p.items-box__body__info__tax (税込)

--- a/app/views/items/_index.html.haml
+++ b/app/views/items/_index.html.haml
@@ -1,13 +1,16 @@
 .items-box-contents.clearfix
-  %section.items-box
-    = link_to items_path do
-      %figure.items-box__image
-        = image_tag "/item.jpg"
-      .items-box__body
-        %h3.items-box__body__name チェックロングタイプ
-        .items-box__body__info.clearfix
-          .items-box__body__info__price ¥890
-          .items-box__body__info__likes
-            %i.fa.fa-heart
-            %span 2
-          %p.items-box__body__info__tax (税込)
+  - items.each do |item|
+    %section.items-box
+      = link_to items_path do
+        %figure.items-box__image
+          = image_tag item.images[0]
+        .items-box__body
+          %h3.items-box__body__name
+            = item.name
+          .items-box__body__info.clearfix
+            .items-box__body__info__price
+            ¥ #{item.price}
+            .items-box__body__info__likes
+              %i.fa.fa-heart
+              %span 2
+            %p.items-box__body__info__tax (税込)

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -12,49 +12,7 @@
   %section.items-box-container.clearfix
     %h3.items-head
       = link_to "レディース 新着アイテム", items_path
-    .items-box-contents.clearfix
-      %section.items-box
-        = link_to items_path do
-          %figure.items-box__image
-            = image_tag "/item.jpg"
-          .items-box__body
-            %h3.items-box__body__name チェックロングタイプ
-            .items-box__body__info.clearfix
-              .items-box__body__info__price ¥890
-              .items-box__body__info__likes
-                %i.fa.fa-heart
-                %span 2
-              %p.items-box__body__info__tax (税込)
-      %section.items-box
-        = link_to items_path do
-          %figure.items-box__image
-            = image_tag "/item.jpg"
-          .items-box__body
-            %h3.items-box__body__name チェックロングタイプ
-            .items-box__body__info.clearfix
-              .items-box__body__info__price ¥890
-              .items-box__body__info__likes
-              %p.items-box__body__info__tax (税込)
-      %section.items-box
-        = link_to items_path do
-          %figure.items-box__image
-            = image_tag "/item.jpg"
-          .items-box__body
-            %h3.items-box__body__name チェックロングタイプ
-            .items-box__body__info.clearfix
-              .items-box__body__info__price ¥890
-              .items-box__body__info__likes
-              %p.items-box__body__info__tax (税込)
-      %section.items-box
-        = link_to items_path do
-          %figure.items-box__image
-            = image_tag "/item.jpg"
-          .items-box__body
-            %h3.items-box__body__name チェックロングタイプ
-            .items-box__body__info.clearfix
-              .items-box__body__info__price ¥890
-              .items-box__body__info__likes
-              %p.items-box__body__info__tax (税込)
+    = render partial: 'index'
     .view-all.clearfix
       = link_to "全ての商品を見る", items_path
   / レディースアイテム新着アイテム ここまで
@@ -62,47 +20,8 @@
   %section.items-box-container.clearfix
     %h3.items-head
       = link_to "メンズ 新着アイテム", items_path
-    .items-box-contents.clearfix
-      %section.items-box
-        = link_to items_path do
-          %figure.items-box__image
-            = image_tag "/item.jpg"
-          .items-box__body
-            %h3.items-box__body__name チェックロングタイプ
-            .items-box__body__info.clearfix
-              .items-box__body__info__price ¥890
-              .items-box__body__info__likes
-              %p.items-box__body__info__tax (税込)
-      %section.items-box
-        = link_to items_path do
-          %figure.items-box__image
-            = image_tag "/item.jpg"
-          .items-box__body
-            %h3.items-box__body__name チェックロングタイプ
-            .items-box__body__info.clearfix
-              .items-box__body__info__price ¥890
-              .items-box__body__info__likes
-              %p.items-box__body__info__tax (税込)
-      %section.items-box
-        = link_to items_path do
-          %figure.items-box__image
-            = image_tag "/item.jpg"
-          .items-box__body
-            %h3.items-box__body__name チェックロングタイプ
-            .items-box__body__info.clearfix
-              .items-box__body__info__price ¥890
-              .items-box__body__info__likes
-              %p.items-box__body__info__tax (税込)
-      %section.items-box
-        = link_to items_path do
-          %figure.items-box__image
-            = image_tag "/item.jpg"
-          .items-box__body
-            %h3.items-box__body__name チェックロングタイプ
-            .items-box__body__info.clearfix
-              .items-box__body__info__price ¥890
-              .items-box__body__info__likes
-              %p.items-box__body__info__tax (税込)
+    = render partial: 'index'
+
     .view-all.clearfix
       = link_to "全ての商品を見る", items_path
   / メンズアイテム新着アイテム ここまで
@@ -114,47 +33,8 @@
   %section.items-box-container.clearfix
     %h3.items-head
       = link_to "コーチ 新着アイテム", items_path
-    .items-box-contents.clearfix
-      %section.items-box
-        = link_to items_path do
-          %figure.items-box__image
-            = image_tag "/item.jpg"
-          .items-box__body
-            %h3.items-box__body__name チェックロングタイプ
-            .items-box__body__info.clearfix
-              .items-box__body__info__price ¥890
-              .items-box__body__info__likes
-              %p.items-box__body__info__tax (税込)
-      %section.items-box
-        = link_to items_path do
-          %figure.items-box__image
-            = image_tag "/item.jpg"
-          .items-box__body
-            %h3.items-box__body__name チェックロングタイプ
-            .items-box__body__info.clearfix
-              .items-box__body__info__price ¥890
-              .items-box__body__info__likes
-              %p.items-box__body__info__tax (税込)
-      %section.items-box
-        = link_to items_path do
-          %figure.items-box__image
-            = image_tag "/item.jpg"
-          .items-box__body
-            %h3.items-box__body__name チェックロングタイプ
-            .items-box__body__info.clearfix
-              .items-box__body__info__price ¥890
-              .items-box__body__info__likes
-              %p.items-box__body__info__tax (税込)
-      %section.items-box
-        = link_to items_path do
-          %figure.items-box__image
-            = image_tag "/item.jpg"
-          .items-box__body
-            %h3.items-box__body__name チェックロングタイプ
-            .items-box__body__info.clearfix
-              .items-box__body__info__price ¥890
-              .items-box__body__info__likes
-              %p.items-box__body__info__tax (税込)
+    = render partial: 'index'
+
     .view-all.clearfix
       = link_to "全ての商品を見る", items_path
   / コーチ新着アイテム ここまで
@@ -162,146 +42,11 @@
   %section.items-box-container.clearfix
     %h3.items-head
       = link_to "ルイヴィトン 新着アイテム", items_path
-    .items-box-contents.clearfix
-      %section.items-box
-        = link_to items_path do
-          %figure.items-box__image
-            = image_tag "/item.jpg"
-          .items-box__body
-            %h3.items-box__body__name チェックロングタイプ
-            .items-box__body__info.clearfix
-              .items-box__body__info__price ¥890
-              .items-box__body__info__likes
-              %p.items-box__body__info__tax (税込)
-      %section.items-box
-        = link_to items_path do
-          %figure.items-box__image
-            = image_tag "/item.jpg"
-          .items-box__body
-            %h3.items-box__body__name チェックロングタイプ
-            .items-box__body__info.clearfix
-              .items-box__body__info__price ¥890
-              .items-box__body__info__likes
-              %p.items-box__body__info__tax (税込)
-      %section.items-box
-        = link_to items_path do
-          %figure.items-box__image
-            = image_tag "/item.jpg"
-          .items-box__body
-            %h3.items-box__body__name チェックロングタイプ
-            .items-box__body__info.clearfix
-              .items-box__body__info__price ¥890
-              .items-box__body__info__likes
-              %p.items-box__body__info__tax (税込)
-      %section.items-box
-        = link_to items_path do
-          %figure.items-box__image
-            = image_tag "/item.jpg"
-          .items-box__body
-            %h3.items-box__body__name チェックロングタイプ
-            .items-box__body__info.clearfix
-              .items-box__body__info__price ¥890
-              .items-box__body__info__likes
-              %p.items-box__body__info__tax (税込)
+    = render partial: 'index'
+
     .view-all.clearfix
       = link_to "全ての商品を見る", items_path
   / ルイヴィトン新着アイテム ここまで
 / ブランド新着アイテム ここまで
 
-
-/ 補足情報
-%aside.app-banner
-  .app-banner__pc
-    .app-banner__pc__inner
-      %h2 スマホでかんたんフリマアプリ
-      %p 今すぐ無料ダウンロード！
-      .app-banner__icon.clearfix
-        %figure
-          = image_tag "topPage/mercari_icon.png", width: "68"
-        %ul.clearfix
-          %li
-            = link_to items_path do
-              = image_tag "topPage/appstore.png", width: "133"
-          %li
-            = link_to items_path do
-              = image_tag "topPage/google.png", width: "133"
-    %figure.asidemain
-      = image_tag "topPage/smartphone.png", width: "300"
-/ 補足情報 ここまで
-/ フッター
-%footer#footer-wrap
-  %nav#footer-nav.clearfix
-    .footer-cell
-      %h2.footer-head メルカリについて
-      %ul
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "採用情報", items_path
-        %li
-          = link_to "プレスリリース", items_path
-        %li
-          = link_to "公式ブログ", items_path
-        %li
-          = link_to "メルカリロゴ利用ガイドライン", items_path
-        %li.footer-social-link
-          = link_to items_path do
-            %i.fa.fa-twitter
-        %li.footer-social-link
-          = link_to items_path do
-            %i.fa.fa-facebook
-    .footer-cell
-      %h2.footer-head ヘルプ&ガイド
-      %ul
-        %li
-          = link_to "メルカリガイド", items_path
-        %li
-          = link_to "らくらくメルカリ便", items_path
-        %li
-          = link_to "ゆうゆうメルカリ便", items_path
-        %li
-          = link_to "大型メルカリ便", items_path
-        %li
-          = link_to "車体取引ガイド", items_path
-        %li
-          = link_to "メルカリあんしん・あんぜん宣言！", items_path
-        %li
-          = link_to "偽ブランド品撲滅への取り組み", items_path
-        %li
-          = link_to "メルカリボックス", items_path
-    .footer-cell
-      %h2.footer-head プライバシーと利用規約
-      .inner-footer-cell
-        %ul
-          %li
-            = link_to "プライバシーポリシー", items_path
-          %li
-            = link_to "メルカリ利用規約", items_path
-          %li
-            = link_to "あんしんスマホサポート制度に関する利用特約", items_path
-          %li
-            = link_to "コンプライアンスポリシー", items_path
-      .inner-footer-cell
-        %ul
-          %li
-            = link_to "個人データの安全管理に関わる基本規約", items_path
-          %li
-            = link_to "特定商取引に関する表記", items_path
-          %li
-            = link_to "資金決済法に基づく表示", items_path
-          %li
-            = link_to "法令順守と犯罪抑止のために", items_path
-          %li
-            = link_to "返品・返金ポリシー", items_path
-
-  .footer-bottom
-    = link_to items_path do
-      = image_tag "/footer-logo.png", height: "33", width: "124"
-    %span.copy-right
-      %small ©︎ 2019 Mercari
-/ フッター ここまで
-/ 出品ボタン
-= link_to new_item_path, class: "exhibit-btn" do
-  %div 出品
-  %i.fa.fa-camera
-/ 出品ボタン ここまで
+= render 'shared/footer'

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,52 +1,40 @@
 = render partial: "shared/header"
 
-/ ヘッダーここまで
-/ メインイメージ
 %section#main-image
   = image_tag "/mainImage.jpg"
-/ メインイメージ ここまで
-/ カテゴリー新着アイテム
+
 %section#pick-up-container
   %h2.pick-up-head ピックアップカテゴリー
-  / レディースアイテム新着アイテム
   %section.items-box-container.clearfix
     %h3.items-head
       = link_to "レディース 新着アイテム", items_path
-    = render partial: 'index'
+    = render partial: 'index', locals: { items: @women_items }
     .view-all.clearfix
       = link_to "全ての商品を見る", items_path
-  / レディースアイテム新着アイテム ここまで
-  / メンズアイテム新着アイテム
+
   %section.items-box-container.clearfix
     %h3.items-head
       = link_to "メンズ 新着アイテム", items_path
-    = render partial: 'index'
-
+    = render partial: 'index', locals: { items: @men_items }
     .view-all.clearfix
       = link_to "全ての商品を見る", items_path
-  / メンズアイテム新着アイテム ここまで
-/ カテゴリー新着アイテム ここまで
-/ カテゴリー新着アイテム
+
+
 %section#pick-up-container
   %h2.pick-up-head ピックアップブランド
-  / コーチ新着アイテム
   %section.items-box-container.clearfix
     %h3.items-head
       = link_to "コーチ 新着アイテム", items_path
-    = render partial: 'index'
-
+    / = render partial: 'index'
     .view-all.clearfix
       = link_to "全ての商品を見る", items_path
-  / コーチ新着アイテム ここまで
-  / ルイヴィトン新着アイテム
+
   %section.items-box-container.clearfix
     %h3.items-head
       = link_to "ルイヴィトン 新着アイテム", items_path
-    = render partial: 'index'
-
+    / = render partial: 'index'
     .view-all.clearfix
       = link_to "全ての商品を見る", items_path
-  / ルイヴィトン新着アイテム ここまで
-/ ブランド新着アイテム ここまで
+
 
 = render 'shared/footer'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -32,11 +32,16 @@
           .item-photo__stage__item
             .item-photo__stage__item__inner
               = image_tag @item.images[0]
+              - if @item.status == "sold"
+                .item-photo__stage__item__inner__budge
+                .item-photo__stage__item__inner__sold
+                  SOLD
         .item-photo__dots
           - @item.images.each do |image|
             .item-photo__dots__dot
               .item-photo__dots__dot__inner
                 = image_tag image
+
       %table.item-detail-table
         %tbody
           %tr

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -111,8 +111,13 @@
       = link_to "#modal", class: "item-buy-btn modal", id: "modal" do
         この商品を削除する
     - else
-      = link_to new_item_cart_path(@item), class: "item-buy-btn" do
-        購入画面へ進む
+      - if @item.status == "exhibited"
+        = link_to new_item_cart_path(@item), class: "item-buy-btn" do
+          購入画面へ進む
+      - else
+        .item-not-buy-btn
+          売り切れました
+
     .item-button-container.clearfix
       .item-button-left
         %button.item-button
@@ -215,85 +220,4 @@
   / 商品コメント部分 ここまで
 / 商品詳細セクション
 
-
-
-
-/ 補足情報
-%aside.app-banner
-  .app-banner__mobile
-    = link_to items_path do
-      %figure.app-banner__icon
-        = image_tag "/mercari_icon.png", width: "50"
-      .app-banner__text
-        スマホかんたんフリマアプリ
-        %span 今すぐ無料ダウンロード!
-/ 補足情報 ここまで
-/ フッター
-%footer#footer-wrap
-  %nav#footer-nav.clearfix
-    .footer-cell
-      %h2.footer-head メルカリについて
-      %ul
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-    .footer-cell
-      %h2.footer-head メルカリについて
-      %ul
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-    .footer-cell
-      %h2.footer-head メルカリについて
-      %ul
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-    .footer-cell
-      %h2.footer-head メルカリについて
-      %ul
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-    .footer-cell
-      %h2.footer-head メルカリについて
-      %ul
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-  .footer-bottom
-    = link_to items_path do
-      = image_tag "/footer-logo.png", height: "33", width: "124"
-    %span.copy-right
-      %small ©︎ 2019 Mercari
-/ フッター ここまで
-/ 出品ボタン
-= link_to items_path, class: "exhibit-btn" do
-  %div 出品
-  %i.fa.fa-camera
-/ 出品ボタン ここまで
+= render 'shared/footer'

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -1,11 +1,21 @@
+
 %aside.app-banner
-  .app-banner__mobile
-    = link_to items_path do
-      %figure.app-banner__icon
-        = image_tag "/mercari_icon.png", width: "50"
-      .app-banner__text
-        スマホかんたんフリマアプリ
-        %span 今すぐ無料ダウンロード!
+  .app-banner__pc
+    .app-banner__pc__inner
+      %h2 スマホでかんたんフリマアプリ
+      %p 今すぐ無料ダウンロード！
+      .app-banner__icon.clearfix
+        %figure
+          = image_tag "topPage/mercari_icon.png", width: "68"
+        %ul.clearfix
+          %li
+            = link_to items_path do
+              = image_tag "topPage/appstore.png", width: "133"
+          %li
+            = link_to items_path do
+              = image_tag "topPage/google.png", width: "133"
+    %figure.asidemain
+      = image_tag "topPage/smartphone.png", width: "300"
 / 補足情報 ここまで
 / フッター
 %footer#footer-wrap
@@ -16,55 +26,63 @@
         %li
           = link_to "会社概要(運営会社)", items_path
         %li
-          = link_to "会社概要(運営会社)", items_path
+          = link_to "採用情報", items_path
         %li
-          = link_to "会社概要(運営会社)", items_path
+          = link_to "プレスリリース", items_path
         %li
-          = link_to "会社概要(運営会社)", items_path
+          = link_to "公式ブログ", items_path
+        %li
+          = link_to "メルカリロゴ利用ガイドライン", items_path
+        %li.footer-social-link
+          = link_to items_path do
+            %i.fa.fa-twitter
+        %li.footer-social-link
+          = link_to items_path do
+            %i.fa.fa-facebook
     .footer-cell
-      %h2.footer-head メルカリについて
+      %h2.footer-head ヘルプ&ガイド
       %ul
         %li
-          = link_to "会社概要(運営会社)", items_path
+          = link_to "メルカリガイド", items_path
         %li
-          = link_to "会社概要(運営会社)", items_path
+          = link_to "らくらくメルカリ便", items_path
         %li
-          = link_to "会社概要(運営会社)", items_path
+          = link_to "ゆうゆうメルカリ便", items_path
         %li
-          = link_to "会社概要(運営会社)", items_path
+          = link_to "大型メルカリ便", items_path
+        %li
+          = link_to "車体取引ガイド", items_path
+        %li
+          = link_to "メルカリあんしん・あんぜん宣言！", items_path
+        %li
+          = link_to "偽ブランド品撲滅への取り組み", items_path
+        %li
+          = link_to "メルカリボックス", items_path
     .footer-cell
-      %h2.footer-head メルカリについて
-      %ul
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-    .footer-cell
-      %h2.footer-head メルカリについて
-      %ul
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-    .footer-cell
-      %h2.footer-head メルカリについて
-      %ul
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
-        %li
-          = link_to "会社概要(運営会社)", items_path
+      %h2.footer-head プライバシーと利用規約
+      .inner-footer-cell
+        %ul
+          %li
+            = link_to "プライバシーポリシー", items_path
+          %li
+            = link_to "メルカリ利用規約", items_path
+          %li
+            = link_to "あんしんスマホサポート制度に関する利用特約", items_path
+          %li
+            = link_to "コンプライアンスポリシー", items_path
+      .inner-footer-cell
+        %ul
+          %li
+            = link_to "個人データの安全管理に関わる基本規約", items_path
+          %li
+            = link_to "特定商取引に関する表記", items_path
+          %li
+            = link_to "資金決済法に基づく表示", items_path
+          %li
+            = link_to "法令順守と犯罪抑止のために", items_path
+          %li
+            = link_to "返品・返金ポリシー", items_path
+
   .footer-bottom
     = link_to items_path do
       = image_tag "/footer-logo.png", height: "33", width: "124"


### PR DESCRIPTION
# WHAT
・レディースとメンズをカテゴリ別に表示
・購入された商品には一覧画面、詳細画面共に「SOLD」がつく
・売り切れた商品は詳細画面の「購入画面へ進む」が「売り切れました」に変わる

# WHY
・カテゴリ別に分けることでユーザーが商品を探しやすくする
・売り切れた商品を再度購入できないようにする

# 備考
・一覧画面のブランドの箇所ですが、ブランドカテゴリー自体まだ作成していないため保留中です。